### PR TITLE
Add bulk product bulk-upload workflow

### DIFF
--- a/src/pages/ProductManagement.tsx
+++ b/src/pages/ProductManagement.tsx
@@ -1,12 +1,13 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Wine } from '../types/wine';
 import { Supplier } from '../types/supplier';
-import { Trash2, Plus, Package, Search, CreditCard as Edit2, X, PlusCircle } from 'lucide-react';
+import { Trash2, Plus, Package, Search, CreditCard as Edit2, X, PlusCircle, Upload, Download } from 'lucide-react';
 import { Button } from '../components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '../components/ui/dialog';
 import { Alert, AlertDescription } from '../components/ui/alert';
 import { Badge } from '../components/ui/badge';
 import { supabase } from '../lib/supabase';
+import { generateProductUploadTemplate, parseProductUploadFile } from '../utils/productUpload';
 
 interface ProductManagementProps {
   onProductsChanged?: () => void;
@@ -22,6 +23,11 @@ export const ProductManagement: React.FC<ProductManagementProps> = ({ onProducts
   const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [uploadMessage, setUploadMessage] = useState<string | null>(null);
+  const [uploadErrors, setUploadErrors] = useState<string[]>([]);
+  const [uploadAlertType, setUploadAlertType] = useState<'error' | 'warning' | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const [formData, setFormData] = useState({
     name: '',
@@ -90,6 +96,117 @@ export const ProductManagement: React.FC<ProductManagementProps> = ({ onProducts
       setSuppliers(data || []);
     } catch (err) {
       console.error('Failed to load suppliers:', err);
+    }
+  };
+
+  const handleDownloadTemplate = () => {
+    generateProductUploadTemplate();
+  };
+
+  const handleFileUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    setUploadMessage(null);
+    setUploadErrors([]);
+    setUploadAlertType(null);
+    setUploading(true);
+
+    try {
+      const result = await parseProductUploadFile(file);
+      const supplierNameLookup = new Map(
+        suppliers.map(supplier => [supplier.name.trim().toLowerCase(), supplier.id])
+      );
+      const supplierIdLookup = new Set(suppliers.map(supplier => supplier.id));
+      const supplierErrors: string[] = [];
+
+      const rowsToUpsert = result.products.map(product => {
+        let supplierId: string | null = null;
+
+        if (product.supplierId) {
+          if (supplierIdLookup.has(product.supplierId)) {
+            supplierId = product.supplierId;
+          } else {
+            supplierErrors.push(
+              `Row ${product.rowNumber}: Supplier ID "${product.supplierId}" was not found.`
+            );
+            return null;
+          }
+        } else if (product.supplier) {
+          const lookupId = supplierNameLookup.get(product.supplier.trim().toLowerCase());
+          if (lookupId) {
+            supplierId = lookupId;
+          } else {
+            supplierErrors.push(
+              `Row ${product.rowNumber}: Supplier "${product.supplier}" was not found. Add the supplier first or leave the field blank.`
+            );
+            return null;
+          }
+        }
+
+        const toNullable = (value?: string) => (value && value.trim() !== '' ? value.trim() : null);
+
+        return {
+          id: product.id || undefined,
+          name: product.name.trim(),
+          description: toNullable(product.description),
+          category: toNullable(product.category) || 'Red Wine',
+          vintage: toNullable(product.vintage),
+          price: product.price,
+          region: toNullable(product.region),
+          varietal: toNullable(product.varietal),
+          supplier_id: supplierId
+        };
+      }).filter((row): row is {
+        id?: string;
+        name: string;
+        description: string | null;
+        category: string;
+        vintage: string | null;
+        price: number;
+        region: string | null;
+        varietal: string | null;
+        supplier_id: string | null;
+      } => row !== null);
+
+      const combinedErrors = [...result.errors, ...supplierErrors];
+
+      if (rowsToUpsert.length === 0) {
+        setUploadErrors(combinedErrors.length ? combinedErrors : ['No valid rows found in the file.']);
+        setUploadAlertType('error');
+        return;
+      }
+
+      const { error: upsertError } = await supabase
+        .from('products')
+        .upsert(rowsToUpsert, { onConflict: 'id' });
+
+      if (upsertError) {
+        throw upsertError;
+      }
+
+      setUploadMessage(`Successfully uploaded ${rowsToUpsert.length} product${rowsToUpsert.length === 1 ? '' : 's'}.`);
+
+      if (combinedErrors.length) {
+        setUploadErrors(combinedErrors);
+        setUploadAlertType('warning');
+      } else {
+        setUploadErrors([]);
+        setUploadAlertType(null);
+      }
+
+      await loadProducts();
+      onProductsChanged?.();
+    } catch (uploadErr) {
+      setUploadErrors([
+        uploadErr instanceof Error ? uploadErr.message : 'Failed to upload products.'
+      ]);
+      setUploadAlertType('error');
+    } finally {
+      setUploading(false);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = '';
+      }
     }
   };
 
@@ -473,6 +590,70 @@ export const ProductManagement: React.FC<ProductManagementProps> = ({ onProducts
               </Alert>
             )}
 
+            <div className="bg-gray-50 border border-gray-200 rounded-lg p-4 mb-6">
+              <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                <div>
+                  <h2 className="text-sm font-semibold text-gray-800">Bulk upload products</h2>
+                  <p className="text-sm text-gray-600 mt-1">
+                    Download the template, fill in your product details, and upload an Excel or CSV file to add or update products in bulk.
+                  </p>
+                </div>
+                <div className="flex flex-wrap gap-3">
+                  <Button
+                    type="button"
+                    onClick={handleDownloadTemplate}
+                    className="bg-white text-burgundy-600 border border-burgundy-200 hover:bg-burgundy-50"
+                  >
+                    <Download className="h-4 w-4 mr-2" />
+                    Download Excel Template
+                  </Button>
+                  <Button
+                    type="button"
+                    onClick={() => fileInputRef.current?.click()}
+                    disabled={uploading}
+                    className="bg-burgundy-600 hover:bg-burgundy-700 text-white"
+                  >
+                    <Upload className="h-4 w-4 mr-2" />
+                    {uploading ? 'Uploading...' : 'Upload Products'}
+                  </Button>
+                </div>
+              </div>
+
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".xlsx,.xls,.csv"
+                onChange={handleFileUpload}
+                className="hidden"
+              />
+
+              {uploadMessage && (
+                <Alert className="mt-4 bg-green-50 border-green-200">
+                  <AlertDescription className="text-green-800">{uploadMessage}</AlertDescription>
+                </Alert>
+              )}
+
+              {uploadAlertType && uploadErrors.length > 0 && (
+                <Alert
+                  className={`mt-4 ${
+                    uploadAlertType === 'warning'
+                      ? 'bg-amber-50 border-amber-200'
+                      : 'bg-red-50 border-red-200'
+                  }`}
+                >
+                  <AlertDescription
+                    className={uploadAlertType === 'warning' ? 'text-amber-800' : 'text-red-800'}
+                  >
+                    <ul className="list-disc pl-5 space-y-1">
+                      {uploadErrors.map((errMsg, index) => (
+                        <li key={index}>{errMsg}</li>
+                      ))}
+                    </ul>
+                  </AlertDescription>
+                </Alert>
+              )}
+            </div>
+
             <div className="relative">
               <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
               <input
@@ -494,7 +675,9 @@ export const ProductManagement: React.FC<ProductManagementProps> = ({ onProducts
             <div className="p-12 text-center">
               <Package className="mx-auto h-12 w-12 text-gray-400 mb-4" />
               <h3 className="text-lg font-medium text-gray-700 mb-2">No products yet</h3>
-              <p className="text-gray-500 mb-4">Get started by adding your first product or uploading a file</p>
+              <p className="text-gray-500 mb-4">
+                Use the bulk upload tools above to import products from Excel/CSV or add them manually.
+              </p>
             </div>
           ) : (
             <div className="overflow-x-auto">

--- a/src/utils/productUpload.ts
+++ b/src/utils/productUpload.ts
@@ -1,0 +1,238 @@
+import Papa from 'papaparse';
+import * as XLSX from 'xlsx';
+import { parseLocaleNumber } from '../types/pricing';
+
+const COLUMN_MAPPINGS = {
+  id: ['id', 'product id', 'product_id'],
+  name: ['name', 'product name', 'wine name'],
+  description: ['description', 'details', 'tasting notes', 'notes'],
+  category: ['category', 'type', 'wine type', 'style'],
+  vintage: ['vintage', 'year'],
+  price: ['price', 'retail price', 'amount', 'selling price', 'unit price'],
+  region: ['region', 'appellation', 'location', 'origin'],
+  varietal: ['varietal', 'grape', 'grape variety', 'variety'],
+  supplier: ['supplier', 'supplier name', 'vendor', 'distributor', 'source'],
+  supplierId: ['supplier id', 'supplier_id']
+};
+
+const normalizeKey = (key: string): string => key.trim().toLowerCase();
+
+const findColumnValue = (row: Record<string, any>, possibleNames: string[]): string => {
+  for (const name of possibleNames) {
+    const value = row[name];
+    if (value !== undefined && value !== null) {
+      const stringValue = String(value).trim();
+      if (stringValue !== '') {
+        return stringValue;
+      }
+    }
+  }
+  return '';
+};
+
+const isRowEmpty = (row: Record<string, any>): boolean => {
+  return Object.values(row).every(value => String(value ?? '').trim() === '');
+};
+
+export interface ProductUploadRow {
+  rowNumber: number;
+  id?: string;
+  name: string;
+  description?: string;
+  category?: string;
+  vintage?: string;
+  price: number;
+  region?: string;
+  varietal?: string;
+  supplier?: string;
+  supplierId?: string;
+}
+
+export interface ProductUploadParseResult {
+  products: ProductUploadRow[];
+  errors: string[];
+}
+
+const processRows = (
+  rows: Record<string, any>[],
+  headerOffset: number
+): ProductUploadParseResult => {
+  const products: ProductUploadRow[] = [];
+  const errors: string[] = [];
+
+  rows.forEach((row, index) => {
+    const rowNumber = headerOffset + index;
+
+    if (isRowEmpty(row)) {
+      return;
+    }
+
+    const name = findColumnValue(row, COLUMN_MAPPINGS.name);
+    if (!name) {
+      errors.push(`Row ${rowNumber}: Missing product name`);
+      return;
+    }
+
+    const priceValue = findColumnValue(row, COLUMN_MAPPINGS.price);
+    let price = priceValue ? parseLocaleNumber(priceValue) : null;
+
+    if (price === null || Number.isNaN(price)) {
+      const numericPrice = Number(priceValue);
+      price = Number.isNaN(numericPrice) ? null : numericPrice;
+    }
+
+    if (price === null || price <= 0) {
+      errors.push(`Row ${rowNumber}: Invalid or missing price`);
+      return;
+    }
+
+    const productRow: ProductUploadRow = {
+      rowNumber,
+      id: findColumnValue(row, COLUMN_MAPPINGS.id) || undefined,
+      name,
+      description: findColumnValue(row, COLUMN_MAPPINGS.description) || undefined,
+      category: findColumnValue(row, COLUMN_MAPPINGS.category) || 'Red Wine',
+      vintage: findColumnValue(row, COLUMN_MAPPINGS.vintage) || undefined,
+      price,
+      region: findColumnValue(row, COLUMN_MAPPINGS.region) || undefined,
+      varietal: findColumnValue(row, COLUMN_MAPPINGS.varietal) || undefined,
+      supplier: findColumnValue(row, COLUMN_MAPPINGS.supplier) || undefined,
+      supplierId: findColumnValue(row, COLUMN_MAPPINGS.supplierId) || undefined
+    };
+
+    products.push(productRow);
+  });
+
+  return { products, errors };
+};
+
+const parseCSV = (file: File): Promise<ProductUploadParseResult> => {
+  return new Promise((resolve) => {
+    Papa.parse<Record<string, any>>(file, {
+      header: true,
+      skipEmptyLines: 'greedy',
+      transformHeader: (header: string) => normalizeKey(header),
+      complete: (results) => {
+        const normalizedRows = results.data.map((row) => {
+          const normalized: Record<string, any> = {};
+          Object.entries(row).forEach(([key, value]) => {
+            if (typeof key === 'string') {
+              normalized[normalizeKey(key)] = value;
+            }
+          });
+          return normalized;
+        });
+
+        resolve(processRows(normalizedRows, 2));
+      },
+      error: () => {
+        resolve({ products: [], errors: ['Failed to parse CSV file'] });
+      }
+    });
+  });
+};
+
+const parseExcel = (file: File): Promise<ProductUploadParseResult> => {
+  return new Promise((resolve) => {
+    const reader = new FileReader();
+
+    reader.onload = (event) => {
+      try {
+        const data = new Uint8Array(event.target?.result as ArrayBuffer);
+        const workbook = XLSX.read(data, { type: 'array' });
+        const sheetName = workbook.SheetNames[0];
+        const worksheet = workbook.Sheets[sheetName];
+        const jsonData = XLSX.utils.sheet_to_json(worksheet, {
+          header: 1,
+          defval: '',
+          blankrows: false
+        });
+
+        if (!jsonData.length) {
+          resolve({ products: [], errors: ['File appears to be empty'] });
+          return;
+        }
+
+        const headers = (jsonData[0] as string[]).map(header => normalizeKey(String(header ?? '')));
+        const records = (jsonData.slice(1) as any[][]).map(row => {
+          const record: Record<string, any> = {};
+          headers.forEach((header, columnIndex) => {
+            record[header] = row[columnIndex];
+          });
+          return record;
+        });
+
+        resolve(processRows(records, 2));
+      } catch (error) {
+        resolve({
+          products: [],
+          errors: [`Failed to parse Excel file: ${error instanceof Error ? error.message : error}`]
+        });
+      }
+    };
+
+    reader.onerror = () => {
+      resolve({ products: [], errors: ['Failed to read file'] });
+    };
+
+    reader.readAsArrayBuffer(file);
+  });
+};
+
+export const parseProductUploadFile = async (file: File): Promise<ProductUploadParseResult> => {
+  const extension = file.name.split('.').pop()?.toLowerCase();
+
+  if (extension === 'csv') {
+    return parseCSV(file);
+  }
+
+  if (extension === 'xlsx' || extension === 'xls') {
+    return parseExcel(file);
+  }
+
+  return {
+    products: [],
+    errors: ['Unsupported file type. Please upload an .xlsx or .csv file.']
+  };
+};
+
+export const generateProductUploadTemplate = (): void => {
+  const workbook = XLSX.utils.book_new();
+
+  const data = [
+    ['ID', 'Name', 'Category', 'Description', 'Vintage', 'Price', 'Region', 'Varietal', 'Supplier', 'Supplier ID'],
+    ['', 'Cabernet Sauvignon Reserve', 'Red Wine', 'Full-bodied red wine with notes of blackcurrant and oak', '2020', '250.00', 'Stellenbosch', 'Cabernet Sauvignon', 'Premium Wines Ltd', ''],
+    ['', 'Chardonnay Estate', 'White Wine', 'Crisp white wine with citrus and vanilla notes', '2022', '180.00', 'Western Cape', 'Chardonnay', 'Premium Wines Ltd', ''],
+    ['', 'Méthode Cap Classique', 'Sparkling Wine', 'Traditional method sparkling wine with fine bubbles', '2019', '320.00', 'Robertson', 'Chardonnay/Pinot Noir', 'Sparkling Specialists', '']
+  ];
+
+  const worksheet = XLSX.utils.aoa_to_sheet(data);
+
+  worksheet['!cols'] = [
+    { width: 15 },
+    { width: 28 },
+    { width: 18 },
+    { width: 45 },
+    { width: 12 },
+    { width: 12 },
+    { width: 18 },
+    { width: 22 },
+    { width: 24 },
+    { width: 18 }
+  ];
+
+  const headerRange = XLSX.utils.decode_range(worksheet['!ref'] || 'A1:J1');
+  for (let column = headerRange.s.c; column <= headerRange.e.c; column++) {
+    const cellAddress = XLSX.utils.encode_cell({ r: 0, c: column });
+    if (worksheet[cellAddress]) {
+      worksheet[cellAddress].s = {
+        font: { bold: true },
+        fill: { fgColor: { rgb: 'E2E8F0' } },
+        alignment: { horizontal: 'center' }
+      };
+    }
+  }
+
+  XLSX.utils.book_append_sheet(workbook, worksheet, 'Product Upload Template');
+  XLSX.writeFile(workbook, 'product-upload-template.xlsx');
+};


### PR DESCRIPTION
## Summary
- add bulk upload controls to the product management page with success and warning feedback
- parse Excel/CSV product files, validate rows, and upsert data to Supabase
- provide a downloadable Excel template for preparing product imports

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e39ce9c7b48329bb56f428a1dc5274