### PR TITLE
Handle optional product IDs during product upload

### DIFF
--- a/src/pages/ProductManagement.tsx
+++ b/src/pages/ProductManagement.tsx
@@ -151,8 +151,17 @@ export const ProductManagement: React.FC<ProductManagementProps> = ({ onProducts
 
         const toNullable = (value?: string) => (value && value.trim() !== '' ? value.trim() : null);
 
-        return {
-          id: product.id || undefined,
+        const payload: {
+          id?: string;
+          name: string;
+          description: string | null;
+          category: string;
+          vintage: string | null;
+          price: number;
+          region: string | null;
+          varietal: string | null;
+          supplier_id: string | null;
+        } = {
           name: product.name.trim(),
           description: toNullable(product.description),
           category: toNullable(product.category) || 'Red Wine',
@@ -162,6 +171,13 @@ export const ProductManagement: React.FC<ProductManagementProps> = ({ onProducts
           varietal: toNullable(product.varietal),
           supplier_id: supplierId
         };
+
+        const trimmedId = product.id?.trim();
+        if (trimmedId) {
+          payload.id = trimmedId;
+        }
+
+        return payload;
       }).filter((row): row is {
         id?: string;
         name: string;


### PR DESCRIPTION
## Summary
- ensure generated product upload payload omits the id field until a trimmed value exists
- keep other product data normalization logic intact while conditionally attaching the id

## Testing
- not run (manual testing recommended)

------
https://chatgpt.com/codex/tasks/task_e_68e3be64a3948329bc48147438bf5e4d